### PR TITLE
add misspelling check in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,12 @@
 pipeline:
+  check_misspellings:
+    image: alpine
+    commands:
+      - apk --no-cache add curl
+      - curl -L -o ./install-misspell.sh https://git.io/misspell
+      - ./install-misspell.sh
+      - misspell .
+
   build:
     image: ruby:latest
     commands:


### PR DESCRIPTION
I still end up having to fix typos here and there weeks after a post goes live like this 
https://github.com/adelowo/personal-site/commit/fcd0f53af8c1c2916e383d5fdfffd2d4dd931c94 . 

This catches all spelling errors before the site is built