### PR TITLE
Update Drone CI to version 1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,7 @@
-pipeline:
+kind: pipeline
+name: default
+
+steps:
   build:
     image: ruby:latest
     commands:
@@ -13,7 +16,6 @@ pipeline:
     source: _site/*
     target: ~/lanre.wtf
     recursive: true
-    user: lanreadelowo
     delete: true
     secrets: [ rsync_key ]
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,26 +2,27 @@ kind: pipeline
 name: default
 
 steps:
-  build:
-    image: ruby:latest
-    commands:
-      - gem update --system
-      - gem install bundler
-      - bundle install
-      - bundle exec jekyll build
+- name: build
+  image: ruby:latest
+  commands:
+    - gem update --system
+    - gem install bundler
+    - bundle install
+    - bundle exec jekyll build
 
-  deploy:
-    image: drillster/drone-rsync
-    hosts: [ "lanre.wtf" ]
-    source: _site/*
-    target: ~/lanre.wtf
-    recursive: true
-    delete: true
-    secrets: [ rsync_key ]
-    when:
-      event: [ push, tag ]
-      local: false
+- name: deploy
+  image: drillster/drone-rsync
+  hosts: [ "lanre.wtf" ]
+  source: _site/*
+  target: ~/lanre.wtf
+  recursive: true
+  delete: true
+  secrets: [ rsync_key ]
+  when:
+    event: [ push, tag ]
+    local: false
 
-branches: master
-when:
+
+trigger:
+  branch: master
   event: [push, pull_request,tag]

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,25 @@
+pipeline:
+  build:
+    image: ruby:latest
+    commands:
+      - gem update --system
+      - gem install bundler
+      - bundle install
+      - bundle exec jekyll build
+
+  deploy:
+    image: drillster/drone-rsync
+    hosts: [ "lanre.wtf" ]
+    source: _site/*
+    target: ~/lanre.wtf
+    recursive: true
+    user: lanreadelowo
+    delete: true
+    secrets: [ rsync_key ]
+    when:
+      event: [ push, tag ]
+      local: false
+
+branches: master
+when:
+  event: [push, pull_request,tag]


### PR DESCRIPTION
As part of the migration, I have updated the CI server to https://builds.lanre.wtf . This repo builds can be found at https://builds.lanre.wtf/adelowo/personal-site


Closes #33 
